### PR TITLE
Feat: a minor custom enhancement.

### DIFF
--- a/Alpaca.Markets/Parameters/AlpacaOptionsStreamingClientConfiguration.cs
+++ b/Alpaca.Markets/Parameters/AlpacaOptionsStreamingClientConfiguration.cs
@@ -60,6 +60,6 @@ public sealed class AlpacaOptionsStreamingClientConfiguration : StreamingClientC
         // Options streaming API uses format: wss://stream.data.alpaca.markets/v1beta1/{feed}
         // where {feed} is either "indicative" or "opra"
         var feedValue = Feed == OptionsFeed.Opra ? "opra" : "indicative";
-        return new Uri(baseUrl, $"v1beta1/{feedValue}");
+        return new Uri(baseUrl, feedValue);
     }
 }

--- a/Alpaca.Markets/WebSocket/ClientWebSocketWrapper.cs
+++ b/Alpaca.Markets/WebSocket/ClientWebSocketWrapper.cs
@@ -14,8 +14,16 @@ internal sealed class ClientWebSocketWrapper : IWebSocket
     public void Dispose() => _client.Dispose();
 
     public Task ConnectAsync(
-        Uri uri, CancellationToken cancellationToken) =>
-        _client.ConnectAsync(uri, cancellationToken);
+        Uri uri, CancellationToken cancellationToken)
+    {
+        // https://learn.microsoft.com/en-us/dotnet/api/system.net.websockets.clientwebsocketoptions.keepaliveinterval?view=net-9.0
+        // https://github.com/dotnet/runtime/blob/d9c4c3e73dcf09435a3cc1cabb23584c9f24b504/src/libraries/System.Net.WebSockets/src/System/Net/WebSockets/WebSocketCreationOptions.cs#L44
+        // If <see cref="WebSocketCreationOptions.KeepAliveTimeout"/> is set, then PING messages are sent and peer's PONG responses are expected, otherwise,
+        // unsolicited PONG messages are used as a keep-alive heartbeat.
+        // The default is <see cref="TimeSpan.Zero"/>.
+        _client.Options.KeepAliveInterval = TimeSpan.FromSeconds(5);
+        return _client.ConnectAsync(uri, cancellationToken);
+    }
 
     public ValueTask SendAsync(
         ReadOnlySequence<Byte> buffer)


### PR DESCRIPTION
## Description
1. Additional `Error.Invoke(...)` in `class  WebSocketTransport`.
2. Additional retry to connect in WS connection in `class  WebSocketTransport`.
3. Fix internal URL to stable option for streaming connection.

## Related PR
- https://github.com/QuantConnect/Lean.Brokerages.Alpaca/pull/46

## SDK PR Fix
- https://github.com/alpacahq/alpaca-trade-api-csharp/pull/806

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
Run:
```
dotnet build -c Release /p:RunAnalyzersDuringBuild=false /p:ApiCompatGenerateSuppressionFile=true
```
Copy files from `...\alpaca-trade-api-csharp\Alpaca.Markets\bin\Release\net8.0` to our repo [Lean Alpaca](https://github.com/QuantConnect/Lean.Brokerages.Alpaca/tree/master/QuantConnect.AlpacaBrokerage).

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
