### PR TITLE
Feat: update trailing stop order type 

### DIFF
--- a/Alpaca.Markets/Parameters/ChangeOrderRequest.cs
+++ b/Alpaca.Markets/Parameters/ChangeOrderRequest.cs
@@ -64,7 +64,7 @@ public sealed class ChangeOrderRequest : Validation.IRequest
     /// Note: you cannot switch between price-based and percent-based trailing types in a single update.
     /// </summary>
     [JsonProperty(PropertyName = "trail", Required = Required.Default, NullValueHandling = NullValueHandling.Ignore)]
-    public decimal? TrailValue { get => TrailOffset?.Value; }
+    public Decimal? TrailValue { get => TrailOffset?.Value; }
 
     internal String GetEndpointUri() => $"v2/orders/{OrderId:D}";
 

--- a/Alpaca.Markets/Parameters/ChangeOrderRequest.cs
+++ b/Alpaca.Markets/Parameters/ChangeOrderRequest.cs
@@ -50,6 +50,22 @@ public sealed class ChangeOrderRequest : Validation.IRequest
     [JsonProperty(PropertyName = "client_order_id", Required = Required.Default, NullValueHandling = NullValueHandling.Ignore)]
     public String? ClientOrderId { get; set; }
 
+    /// <summary>
+    /// Gets or sets the trailing offset details used to calculate <see cref="TrailValue"/>.
+    /// This property is ignored during JSON serialization and is used only to derive the <c>trail</c> payload.
+    /// </summary>
+    [JsonIgnore]
+    [UsedImplicitly]
+    public TrailOffset? TrailOffset { get; set; }
+
+    /// <summary>
+    /// Gets the trailing value that will be sent in the request payload (either <c>trail_price</c> or <c>trail_percent</c>).
+    /// This update applies only to orders of type <c>trailing_stop</c> and only before the stop price is triggered.
+    /// Note: you cannot switch between price-based and percent-based trailing types in a single update.
+    /// </summary>
+    [JsonProperty(PropertyName = "trail", Required = Required.Default, NullValueHandling = NullValueHandling.Ignore)]
+    public decimal? TrailValue { get => TrailOffset?.Value; }
+
     internal String GetEndpointUri() => $"v2/orders/{OrderId:D}";
 
     IEnumerable<RequestValidationException?> Validation.IRequest.GetExceptions()

--- a/Alpaca.Markets/PublicAPI.Unshipped.txt
+++ b/Alpaca.Markets/PublicAPI.Unshipped.txt
@@ -1,1 +1,4 @@
 ﻿#nullable enable
+Alpaca.Markets.ChangeOrderRequest.TrailOffset.get -> Alpaca.Markets.TrailOffset?
+Alpaca.Markets.ChangeOrderRequest.TrailOffset.set -> void
+Alpaca.Markets.ChangeOrderRequest.TrailValue.get -> decimal?


### PR DESCRIPTION
## Description
Add Property to Update `Trailing Stop Market Orders.

<img width="831" height="211" alt="image" src="https://github.com/user-attachments/assets/64ea3d3d-fe98-4baf-bba1-1e0bc417aafc" />

> [docs](https://docs.alpaca.markets/docs/orders-at-alpaca#trailing-stop-orders)

## Related PR
- https://github.com/QuantConnect/Lean.Brokerages.Alpaca/pull/48

## Type of change
- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
